### PR TITLE
docs(README): misc doc changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 cbor-*.tar
 
+# Temporary files, for example, from tests.
+/tmp/

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,5 @@
+# MIT License
+
 Copyright (c) 2019 Thomas Cioppettini
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # CBOR
 
+[![Module Version](https://img.shields.io/hexpm/v/cbor.svg)](https://hex.pm/packages/cbor)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/cbor/)
+[![Total Download](https://img.shields.io/hexpm/dt/cbor.svg)](https://hex.pm/packages/cbor)
+[![License](https://img.shields.io/hexpm/l/cbor.svg)](https://github.com/scalpel-software/cbor/blob/master/LICENSE.md)
+[![Last Updated](https://img.shields.io/github/last-commit/scalpel-software/cbor.svg)](https://github.com/scalpel-software/cbor/commits/master)
+
 Implementation of RFC 7049 [CBOR](http://cbor.io) (Concise Binary
 Object Representation) for Elixir.
 
@@ -12,7 +18,7 @@ This library is a fork of the no longer maintained excbor project.
 
 For those migrating from previous versions of this library there are breaking changes that you should be aware of.
 
-The module `Cbor` has been renamed to `CBOR`
+The module `Cbor` has been renamed to `CBOR`.
 
 CBOR.decode will return a three item tuple of the form `{:ok, decoded, rest}`, instead of returning the decoded object. In the wild there are APIs that concat CBOR objects together. The `rest` variable includes any leftover information from the decoding operation in case you need to decode multiple objects.
 
@@ -35,7 +41,7 @@ end
 ## Usage
 
 This library follows the standard API for CBOR libraries by exposing two methods
-on the CBOR module `encode/1` and `decode/1`.
+on the CBOR module `CBOR.encode/1` and `CBOR.decode/1`.
 
 ### Encoding
 
@@ -79,11 +85,11 @@ Elixir and erlang have no concept of infinity, negative infinity and NaN. If you
 %CBOR.Tag{tag: :float, value: :nan}
 ```
 
-CBOR.Tag is also useful if you want to extend CBOR for internal applications
+`CBOR.Tag` is also useful if you want to extend `CBOR` for internal applications
 
 ## Custom Encoding
 
-If you want to encode something that is not supported out of the box you can implement the CBOR.Encoder protocol for the module. You only have to implement a single `encode_into/2` function. An example for encoding a Money struct is given below.
+If you want to encode something that is not supported out of the box you can implement the `CBOR.Encoder` protocol for the module. You only have to implement a single `CBOR.Encoder.encode_into/2` function. An example for encoding a Money struct is given below.
 
 ```elixir
 defimpl CBOR.Encoder, for: Money do
@@ -99,3 +105,10 @@ Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_do
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at [https://hexdocs.pm/cbor](https://hexdocs.pm/cbor).
 
+
+## Copyright and License
+
+Copyright (c) 2019 Thomas Cioppettini
+
+This work is free. You can redistribute it and/or modify it under the
+terms of the MIT License. See the [LICENSE.md](./LICENSE.md) file for more details.

--- a/lib/cbor.ex
+++ b/lib/cbor.ex
@@ -8,73 +8,73 @@ defmodule CBOR do
 
   The objectives of CBOR, roughly in decreasing order of importance are:
 
-   1.  The representation must be able to unambiguously encode most
-       common data formats used in Internet standards.
+  1.  The representation must be able to unambiguously encode most
+      common data formats used in Internet standards.
 
-       *  It must represent a reasonable set of basic data types and
-          structures using binary encoding.  "Reasonable" here is
-          largely influenced by the capabilities of JSON, with the major
-          addition of binary byte strings.  The structures supported are
-          limited to arrays and trees; loops and lattice-style graphs
-          are not supported.
+      *  It must represent a reasonable set of basic data types and
+         structures using binary encoding.  "Reasonable" here is
+         largely influenced by the capabilities of JSON, with the major
+         addition of binary byte strings.  The structures supported are
+         limited to arrays and trees; loops and lattice-style graphs
+         are not supported.
 
        *  There is no requirement that all data formats be uniquely
           encoded; that is, it is acceptable that the number "7" might
           be encoded in multiple different ways.
 
-    2.  The code for an encoder or decoder must be able to be compact in
-        order to support systems with very limited memory, processor
-        power, and instruction sets.
+  2.  The code for an encoder or decoder must be able to be compact in
+      order to support systems with very limited memory, processor
+      power, and instruction sets.
 
-       *  An encoder and a decoder need to be implementable in a very
-          small amount of code (for example, in class 1 constrained
-          nodes as defined in [CNN-TERMS]).
+      *  An encoder and a decoder need to be implementable in a very
+         small amount of code (for example, in class 1 constrained
+         nodes as defined in [CNN-TERMS]).
 
-       *  The format should use contemporary machine representations of
-          data (for example, not requiring binary-to-decimal
-          conversion).
+      *  The format should use contemporary machine representations of
+         data (for example, not requiring binary-to-decimal
+         conversion).
 
-    3.  Data must be able to be decoded without a schema description.
+  3.  Data must be able to be decoded without a schema description.
 
-       *  Similar to JSON, encoded data should be self-describing so
+      *  Similar to JSON, encoded data should be self-describing so
           that a generic decoder can be written.
 
-    4.  The serialization must be reasonably compact, but data
-        compactness is secondary to code compactness for the encoder and
-        decoder.
+  4.  The serialization must be reasonably compact, but data
+      compactness is secondary to code compactness for the encoder and
+      decoder.
 
-       *  "Reasonable" here is bounded by JSON as an upper bound in
-          size, and by implementation complexity maintaining a lower
-          bound.  Using either general compression schemes or extensive
-          bit-fiddling violates the complexity goals.
+      *  "Reasonable" here is bounded by JSON as an upper bound in
+         size, and by implementation complexity maintaining a lower
+         bound.  Using either general compression schemes or extensive
+         bit-fiddling violates the complexity goals.
 
-    5.  The format must be applicable to both constrained nodes and high-
-        volume applications.
+  5.  The format must be applicable to both constrained nodes and high-
+      volume applications.
 
-       *  This means it must be reasonably frugal in CPU usage for both
-          encoding and decoding.  This is relevant both for constrained
-          nodes and for potential usage in applications with a very high
-          volume of data.
+      *  This means it must be reasonably frugal in CPU usage for both
+         encoding and decoding.  This is relevant both for constrained
+         nodes and for potential usage in applications with a very high
+         volume of data.
 
-    6.  The format must support all JSON data types for conversion to and
-        from JSON.
+  6.  The format must support all JSON data types for conversion to and
+      from JSON.
 
-       *  It must support a reasonable level of conversion as long as
-          the data represented is within the capabilities of JSON.  It
-          must be possible to define a unidirectional mapping towards
-          JSON for all types of data.
+      *  It must support a reasonable level of conversion as long as
+         the data represented is within the capabilities of JSON.  It
+         must be possible to define a unidirectional mapping towards
+         JSON for all types of data.
 
-    7.  The format must be extensible, and the extended data must be
-        decodable by earlier decoders.
+  7.  The format must be extensible, and the extended data must be
+      decodable by earlier decoders.
 
-       *  The format is designed for decades of use.
+      *  The format is designed for decades of use.
 
-       *  The format must support a form of extensibility that allows
-          fallback so that a decoder that does not understand an
-          extension can still decode the message.
+      *  The format must support a form of extensibility that allows
+         fallback so that a decoder that does not understand an
+         extension can still decode the message.
 
-       *  The format must be able to be extended in the future by later
-          IETF standards.
+      *  The format must be able to be extended in the future by later
+         IETF standards.
   """
 
   @doc """
@@ -91,6 +91,7 @@ defmodule CBOR do
 
       iex> CBOR.encode(%{"a" => 1, "b" => [2, 3]})
       <<162, 97, 97, 1, 97, 98, 130, 2, 3>>
+
   """
   @spec encode(any()) :: binary()
   def encode(value), do: CBOR.Encoder.encode_into(value, <<>>)
@@ -108,6 +109,7 @@ defmodule CBOR do
 
       iex> CBOR.decode(<<162, 97, 97, 1, 97, 98, 130, 2, 3>>)
       {:ok, %{"a" => 1, "b" => [2, 3]}, ""}
+
   """
   @spec decode(binary()) :: {:ok, any(), binary()} | {:error, atom}
   def decode(binary) do

--- a/lib/cbor/encoder.ex
+++ b/lib/cbor/encoder.ex
@@ -1,5 +1,8 @@
 defprotocol CBOR.Encoder do
-  @doc "Converts an Elixir data type to its representation in CBOR"
+  @doc """
+  Converts an Elixir data type to its representation in CBOR.
+  """
+
   def encode_into(element, acc)
 end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,33 +1,52 @@
 defmodule Cbor.MixProject do
   use Mix.Project
 
+  @source_url "https://github.com/scalpel-software/cbor"
+  @version "1.0.0"
+
   def project do
     [
       app: :cbor,
-      version: "1.0.0",
+      version: @version,
       elixir: "~> 1.0",
       start_permanent: Mix.env() == :prod,
-      description: "Implementation of RFC 7049 (Concise Binary Object Representation)",
-      package: [
-        maintainers: ["tomciopp"],
-        licenses: ["MIT"],
-        links: %{"GitHub" => "https://github.com/scalpel-software/cbor"}
-      ],
-      deps: deps()
+      package: package(),
+      deps: deps(),
+      docs: docs()
     ]
   end
 
-  # Run "mix help compile.app" to learn about applications.
   def application do
     [
       extra_applications: [:logger]
     ]
   end
 
-  # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:ex_doc, "~> 0.21", only: :dev, runtime: false}
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
+    ]
+  end
+
+  defp package do
+    [
+      description: "Implementation of RFC 7049 (Concise Binary Object Representation)",
+      maintainers: ["tomciopp"],
+      licenses: ["MIT"],
+      links: %{"GitHub" => @source_url}
+    ]
+  end
+
+  defp docs do
+    [
+      extras: [
+        "LICENSE.md": [title: "License"],
+        "README.md": [title: "Overview"]
+      ],
+      main: "readme",
+      source_url: @source_url,
+      source_ref: "#v{@version}",
+      formatters: ["html"]
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,10 @@
 %{
   "cbor": {:hex, :cbor, "0.1.8", "8996d095d80b69d7a4a2c47799e6c7ee7f195192cae14395babf1c97f2c4a999", [:mix], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.21.1", "5ac36660846967cd869255f4426467a11672fec3d8db602c429425ce5b613b90", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm", "e3be2bc3ae67781db529b80aa7e7c49904a988596e2dbff897425b48b3581161"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.15", "b29e8e729f4aa4a00436580dcc2c9c5c51890613457c193cc8525c388ccb2f06", [:mix], [], "hexpm", "044523d6438ea19c1b8ec877ec221b008661d3c27e3b848f4c879f500421ca5c"},
+  "ex_doc": {:hex, :ex_doc, "0.25.2", "4f1cae793c4d132e06674b282f1d9ea3bf409bcca027ddb2fe177c4eed6a253f", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "5b0c172e87ac27f14dfd152d52a145238ec71a95efbf29849550278c58a393d6"},
+  "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.15.1", "b5888c880d17d1cc3e598f05cdb5b5a91b7b17ac4eaf5f297cb697663a1094dd", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "db68c173234b07ab2a07f645a5acdc117b9f99d69ebf521821d89690ae6c6ec8"},
+  "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
+  "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
 }


### PR DESCRIPTION
Besides other documentation changes, this commit ensures the generated
HTML doc for HexDocs.pm will become the source of truth for this Elixir
library and leverage on latest features of ExDoc.