### PR TITLE
feat(CBOR)!: rescue match error from decoder

### DIFF
--- a/lib/cbor.ex
+++ b/lib/cbor.ex
@@ -117,6 +117,7 @@ defmodule CBOR do
       perform_decoding(binary)
     rescue
       FunctionClauseError -> {:error, :cbor_function_clause_error}
+      MatchError -> {:error, :cbor_match_error}
     end
   end
 


### PR DESCRIPTION
This PR adds an additional clause in `CBOR.decode/1`'s `rescue` clause to handle match errors.

Current behaviour:
```
iex(1)> CBOR.decode("foo") 
** (MatchError) no match of right hand side value: "oo"
    (cbor 1.0.0) lib/cbor/decoder.ex:53: CBOR.Decoder.decode_string/2
    (cbor 1.0.0) lib/cbor.ex:122: CBOR.perform_decoding/1
    (cbor 1.0.0) lib/cbor.ex:115: CBOR.decode/1
    iex:1: (file)
```